### PR TITLE
fixed bug with file permissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * `CreatePackageReport()` now outputs an object of new class `PackageReport` (instead of a list of reporters). This object will let you interactively manipulate the included reporter objects to customize the report, and regenerate the report on demand. You can also instantiate and interact with a `PackageReport` object directly without `CreatePackageReport()`.
 
+## BUG FIXES
+
+* Fixed a bug which could cause `CreatePackageReport()` to fail if being run by a user who doesn't have write access to wherever `pkgnet` was originally installed.
+
 # pkgnet 0.4.0
 
 ## NEW FEATURES

--- a/R/CreatePackageReport.R
+++ b/R/CreatePackageReport.R
@@ -155,6 +155,8 @@ PackageReport <- R6::R6Class(
                 )
                 , output_dir = dirname(self$report_path)
                 , output_file = basename(self$report_path)
+                , intermediates_dir = tempdir()
+                , clean = FALSE
                 , quiet = TRUE
                 , params = list(
                     reporters = private$reporters


### PR DESCRIPTION
I ran into a situation today where I was running `pkgnet::CreatePackageReport()` in a docker container as part of a CI process. The tasks in my CI are run as a different user than the one used to build the container, and I think that as a result I ended up with my CI code able to *read* R packages (e.g. with `library()`) but not able to write to the place(s) where R writes package files.

That is my best explanation for this error I saw:

```
SummaryReporter
DependencyReporter
FunctionReporter
InheritanceReporter
INFO [2019-07-25 21:00:57] Checking installed packages...
INFO [2019-07-25 21:00:57] Found '[REDACTED]' in installed packages.
INFO [2019-07-25 21:00:57] Checking installed packages...
INFO [2019-07-25 21:00:57] Found '[REDACTED]'in installed packages.
INFO [2019-07-25 21:00:57] Checking installed packages...
INFO [2019-07-25 21:00:57] Found '[REDACTED]' in installed packages.
INFO [2019-07-25 21:00:57] Checking installed packages...
INFO [2019-07-25 21:00:57] Found '[REDACTED]' in installed packages.
INFO [2019-07-25 21:00:57] Rendering package report...
Error in file(con, "w") : cannot open the connection
Calls: <Anonymous> ... <Anonymous> -> <Anonymous> -> write_utf8 -> writeLines -> file
In addition: Warning message:
In file(con, "w") :
  cannot open file 'package_report.knit.md': Permission denied
Execution halted
```

I looked into `?rmarkdown::render()` and found that it has keyword argument `intermediates_dir` that controls where files (like this intermediate `.md` file) created while knitting are written to. According to those docs, that parameter is `NULL` by default and if you don't set it, `rmarkdown` will use the location of the input doc as the default place to store intermediates. In the case of `pkgnet::CreatePackageReport()`, that location is wherever `pkgnet` is installed!

Since that directory is not guaranteed to be writeable by R code calling `pkgnet::CreatePackageReport()`, in this PR I propose that we explicitly set it to a `tempdir()` (which I think is guaranteed to be writeable). I also propose setting `clean = FALSE` to prevent `rmarkdown` from trying to delete it...that will happen automagically in the way that R cleans up temp files and temp directories.