### PR TITLE
changed to personal email address in DESCRIPTIONs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Get Network Representation of an R Package
 Version: 0.4.0.9999
 Authors@R: c(
     person("Brian", "Burns", email = "brian.burns@uptake.com", role = c("aut", "cre")),
-    person("James", "Lamb", email = "james.lamb@uptake.com", role = c("aut")),
+    person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut")),
     person("Patrick", "Boueri", email = "patrick.boueri@uptake.com", role = c("ctb")),
     person("Jay", "Qi", email = "jay.qi@uptake.com", role = c("aut"))
     )
@@ -31,7 +31,7 @@ Imports:
     visNetwork
 Suggests:
     devtools,
-    testthat, 
+    testthat,
     withr
 License: BSD_3_clause + file LICENSE
 URL: https://github.com/uptake/pkgnet, https://uptake.github.io/pkgnet/

--- a/inst/baseballstats/DESCRIPTION
+++ b/inst/baseballstats/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Compute basic baseball statistics
 Version: 0.1
 Author: Uptake Data Science
 Authors@R: c(
-    person("James", "Lamb", email = "james.lamb@uptake.com", role = c("aut", "cre")),
+    person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut", "cre")),
     person("Brian", "Burns", email = "brian.burns@uptake.com", role = c("aut")))
 Maintainer: James Lamb <james.lamb@uptake.com>
 Description: This package is used to test the functions in `pkgnet`.

--- a/inst/sartre/DESCRIPTION
+++ b/inst/sartre/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.1
 Author: Uptake Data Science
 Authors@R: c(
     person("Brian", "Burns", email = "brian.burns@uptake.com", role = c("aut", "cre")),
-    person("James", "Lamb", email = "james.lamb@uptake.com", role = c("aut"))
+    person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut"))
     )
 Maintainer: Brian Burns <Brian.Burns@uptake.com>
 Description: This package is used to test the functions in `pkgnet`.  It's a "nothing" network. Get it?


### PR DESCRIPTION
Soon `james.lamb@uptake.com` won't be a thing. Changing it here so all our docs will be correct.