### PR TITLE
fixed bug in set_plot_node_color_scheme()

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -229,11 +229,14 @@ AbstractGraphReporter <- R6::R6Class(
                 })
             }
 
-            if (!all(areColors(palette))) {
-                notColors <- names(areColors)[areColors == FALSE]
+            colorChecks <- areColors(palette)
+            if (!all(colorChecks)) {
+                notColors <- names(colorChecks)[colorChecks == FALSE]
                 notColorsTXT <- paste(notColors, collapse = ", ")
-                log_fatal(sprintf("The following are invalid colors: %s"
-                                  , notColorsTXT))
+                log_fatal(sprintf(
+                    "The following are invalid colors: %s"
+                    , notColorsTXT
+                ))
             }
 
             private$plotNodeColorScheme <- list(

--- a/tests/testthat/test-AbstractGraphReporter.R
+++ b/tests/testthat/test-AbstractGraphReporter.R
@@ -65,6 +65,29 @@ test_that("AbstractGraphReporter errors on unimplemented methods", {
     }, regexp = "Reporter must set valid graph class")
 })
 
+test_that("AbstractGraphReporter$set_plot_node_color_scheme() correctly sets color palette", {
+    x <- pkgnet:::AbstractGraphReporter$new()
+    res <- x$.__enclos_env__$private$set_plot_node_color_scheme(
+        field = "blegh"
+        , palette = c("red", "blue")
+    )
+    color_scheme <- x$.__enclos_env__$private$plotNodeColorScheme
+    expect_identical(
+        color_scheme
+        , list(field = "blegh", palette = c("red", "blue"))
+    )
+})
+
+test_that("AbstractGraphReporter$set_plot_node_color_scheme() correctly rejects bad colors", {
+    x <- pkgnet:::AbstractGraphReporter$new()
+    expect_error({
+        res <- x$.__enclos_env__$private$set_plot_node_color_scheme(
+            field = "blegh"
+            , palette = c("#32CD32", "32CD32")
+        )
+    }, "The following are invalid color")
+})
+
 ### HELPER FUNCTIONS
 
 test_that(".igraphAvailableLayouts returns layouts correctly", {
@@ -72,8 +95,6 @@ test_that(".igraphAvailableLayouts returns layouts correctly", {
         length(pkgnet:::.igraphAvailableLayouts()) > 0
     })
 })
-
-
 
 ##### TEST TEAR DOWN #####
 


### PR DESCRIPTION
While working on #244 , I noticed that the code for handling bad colors provided to `AbstractGraphReporter$set_plot_node_color_scheme()` is incorrect.

If you run the code I added in these unit tests (providing an invalid color), you'll get this cryptic error

```r
Error in areColors == FALSE : 
  comparison (1) is possible only for atomic and list types
```

I didn't update NEWS since this is not a user-facing change.