### PR TITLE
Only round the numeric columns in the output table that have at least…

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -94,17 +94,10 @@ AbstractGraphReporter <- R6::R6Class(
             )
 
             # Round the double columns to three digits for formatting reasons
-
-            # what are the double columns (but still may contain values with all integers)?
-            numDCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
-
-            # Check if each individual value in a double column is an integer,
-            # If at least one of the values is not an integers, then we want to round only those columns
-            numNonIntDCols <- names(which(unlist(lapply(tableObj$x$data[ ,numDCols],
-              function(x) sum(as.integer(x) != x) > 0))))
+            doubleCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
 
             tableObj <- DT::formatRound(
-                columns = numNonIntDCols
+                columns = doubleCols
                 , table = tableObj
                 , digits = 3
             )

--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -96,12 +96,10 @@ AbstractGraphReporter <- R6::R6Class(
             # Round the double columns to three digits for formatting reasons
 
             # what are the double columns (but still may contain values with all integers)?
-
             numDCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
 
             # Check if each individual value in a double column is an integer,
             # If at least one of the values is not an integers, then we want to round only those columns
-
             numNonIntDCols <- names(which(unlist(lapply(tableObj$x$data[ ,numDCols],
               function(x) sum(as.integer(x) != x) > 0))))
 

--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -94,11 +94,21 @@ AbstractGraphReporter <- R6::R6Class(
             )
 
             # Round the double columns to three digits for formatting reasons
-            numCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
+
+            # what are the double columns (but still may contain values with all integers)?
+
+            numDCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
+
+            # Check if each individual value in a double column is an integer,
+            # If at least one of the values is not an integers, then we want to round only those columns
+
+            numNonIntDCols <- names(which(unlist(lapply(tableObj$x$data[ ,numDCols],
+              function(x) sum(as.integer(x) != x) > 0))))
+
             tableObj <- DT::formatRound(
-                columns = numCols
+                columns = numNonIntDCols
                 , table = tableObj
-                , digits=3
+                , digits = 3
             )
             return(tableObj)
         }

--- a/R/GraphClasses.R
+++ b/R/GraphClasses.R
@@ -607,3 +607,4 @@ DirectedGraph <- R6::R6Class(
 #'     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
 #'     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
 #' }
+NULL

--- a/R/GraphClasses.R
+++ b/R/GraphClasses.R
@@ -128,7 +128,7 @@ AbstractGraph <- R6::R6Class(
     classname = "AbstractGraph"
     , public = list(
         initialize = function(nodes, edges) {
-            
+
             # Input validation
             assertthat::assert_that(
                 data.table::is.data.table(nodes)
@@ -136,30 +136,30 @@ AbstractGraph <- R6::R6Class(
                 , data.table::is.data.table(edges)
                 , all(c('SOURCE', 'TARGET') %in% names(edges))
             )
-            
+
             # Store pointers to node and edge data.tables
             private$protected$nodes <- nodes
             private$protected$edges <- edges
-            
+
             return(invisible(self))
         }
-        
+
         , node_measures = function(measures = NULL){
-            
+
             # If not specifying, return node table
             if (is.null(measures)) {
                 return(self$nodes)
             }
-            
+
             assertthat::assert_that(is.character(measures))
-            
+
             for (m in measures) {
                 # Input validation
                 assertthat::assert_that(
                     all(m %in% self$available_node_measures)
                     , msg = sprintf('%s not in $available_node_measures()', m)
                 )
-                
+
                 # If not already calculated it, calculate and add to node DT
                 if (!m %in% names(self$nodes)) {
                     log_info(sprintf("Calculating %s...", m))
@@ -172,26 +172,26 @@ AbstractGraph <- R6::R6Class(
                     self$nodes[, eval(m) := resultDT[node, result]]
                 }
             }
-            
+
             return(self$nodes[, .SD, .SDcols = c('node', measures)])
         }
-        
+
         , graph_measures = function(measures = NULL){
-            
+
             # If not specifying, return full list
             if (is.null(measures)) {
                 return(private$protected$graph_measures)
             }
-            
+
             assertthat::assert_that(is.character(measures))
-            
+
             for (m in measures) {
                 # Input validation
                 assertthat::assert_that(
                     m %in% self$available_graph_measures
                     , msg = sprintf('%s not in $available_graph_measures()', m)
                 )
-                
+
                 # If not already calculated, calculate
                 if (!m %in% names(private$protected$graph_measures)) {
                     log_info(sprintf("Calculating %s", m))
@@ -201,19 +201,19 @@ AbstractGraph <- R6::R6Class(
             }
             return(private$protected$graph_measures[measures])
         }
-        
+
         , print = function(){
             print(self$igraph)
             invisible(self)
         }
-        
+
     ) # /public
-    
+
     , active = list(
         # Read-only access to node and edge data.tables
         nodes = function(){return(private$protected$nodes)}
         , edges = function(){return(private$protected$edges)}
-        
+
         # Read-only access to igraph objects
         , igraph = function(){
             if (is.null(private$protected$igraph)) {
@@ -221,24 +221,24 @@ AbstractGraph <- R6::R6Class(
             }
             return(private$protected$igraph)
         }
-        
+
         , available_node_measures = function(){
             return(names(private$node_measure_functions))
         }
-        
+
         , available_graph_measures = function(){
             return(names(private$graph_measure_functions))
         }
-        
+
         , default_node_measures = function(){
             log_fatal('Default node measures not implemented.')
         }
-        
+
         , default_graph_measures = function(){
             log_fatal('Default graph measures not implemented.')
         }
     ) # /active
-    
+
     , private = list(
         protected = list(
             nodes = NULL
@@ -246,11 +246,11 @@ AbstractGraph <- R6::R6Class(
             , igraph = NULL
             , graph_measures = list()
         )
-        
+
         , initialize_igraph = function(directed){
-            
+
             log_info("Constructing igraph object...")
-            
+
             # Connected graph
             if (nrow(self$edges) > 0) {
                 # A graph with edges
@@ -261,33 +261,33 @@ AbstractGraph <- R6::R6Class(
             } else {
                 connectedGraph <- igraph::make_empty_graph(directed = directed)
             }
-            
+
             # Unconnected graph
             orphanNodes <- base::setdiff(
                 self$nodes[, node]
                 , unique(c(self$edges[, SOURCE], self$edges[, TARGET]))
             )
             unconnectedGraph <- igraph::make_empty_graph(directed = directed) + igraph::vertex(orphanNodes)
-            
+
             # Complete graph
             completeGraph <- connectedGraph + unconnectedGraph
-            
+
             # Store in protected cache
             private$protected$igraph <- completeGraph
-            
+
             log_info("...done constructing igraph object.")
-            
+
             return(invisible(NULL))
         } # /initialize_igraph
-        
+
         # Functions for node measures
         # All functions should return a named vector of node measure values
         , node_measure_functions = list()
-        
+
         # Functions for graph-level measures
         # All functions should return numeric of length 1
         , graph_measure_functions = list()
-        
+
     )  # /private
 )
 
@@ -333,7 +333,7 @@ DirectedGraph <- R6::R6Class(
                 , "pageRank"
             ))
         }
-        
+
         , default_graph_measures = function() {
             return(c(
                 "graphOutDegree"
@@ -343,16 +343,16 @@ DirectedGraph <- R6::R6Class(
         }
     )
     , private = list(
-        
+
         # Initialize igraph object
         initialize_igraph = function() {
             super$initialize_igraph(directed = TRUE)
         }
-        
+
         # Functions for node measures
         # All functions should return a named vector of node measure values
         , node_measure_functions = list(
-            
+
             # Out-Degree
             outDegree = function(self){
                 result <- igraph::degree(
@@ -363,7 +363,7 @@ DirectedGraph <- R6::R6Class(
                 mode(result) <- "integer"
                 return(result)
             }
-            
+
             # In-Degree
             , inDegree = function(self){
                 result <- igraph::degree(
@@ -374,7 +374,7 @@ DirectedGraph <- R6::R6Class(
                 mode(result) <- "integer"
                 return(result)
             }
-            
+
             # Out-Closeness
             # Closeness doesn't really work for directed graphs that are not
             # strongly connected.
@@ -387,7 +387,7 @@ DirectedGraph <- R6::R6Class(
                     , normalized = TRUE
                 ))
             }
-            
+
             # In-Closeness
             # Closeness doesn't really work for directed graphs that are not
             # strongly connected.
@@ -400,7 +400,7 @@ DirectedGraph <- R6::R6Class(
                     , normalized = TRUE
                 ))
             }
-            
+
             # Number of Recursive Dependencies
             , numRecursiveDeps = function(self){
                 # Calculate using out-neighborhood size with order of longest
@@ -416,7 +416,7 @@ DirectedGraph <- R6::R6Class(
                 mode(result) <- "integer"
                 return(result)
             }
-            
+
             # Number of Recursive Reverse Dependencies
             , numRecursiveRevDeps = function(self){
                 # Calculate using in-neighborhood size with order of longest
@@ -432,7 +432,7 @@ DirectedGraph <- R6::R6Class(
                 mode(result) <- "integer"
                 return(result)
             }
-            
+
             # Betweenness
             , betweenness = function(self){
                 igraph::betweenness(
@@ -440,7 +440,7 @@ DirectedGraph <- R6::R6Class(
                     , directed = TRUE
                 )
             }
-            
+
             # Page Rank
             , pageRank = function(self){
                 igraph::page_rank(
@@ -448,7 +448,7 @@ DirectedGraph <- R6::R6Class(
                     , directed = TRUE
                 )$vector
             }
-            
+
             # Hub Score
             , hubScore = function(self){
                 igraph::hub_score(
@@ -456,7 +456,7 @@ DirectedGraph <- R6::R6Class(
                     , scale = TRUE
                 )$vector
             }
-            
+
             # Authority Score
             , authorityScore = function(self){
                 igraph::authority_score(
@@ -464,13 +464,13 @@ DirectedGraph <- R6::R6Class(
                     , scale = TRUE
                 )$vector
             }
-            
+
         ) #/node_measure_functions
-        
+
         # Functions for graph-level measures
         # All functions should return numeric of length 1
         , graph_measure_functions = list(
-            
+
             graphOutDegree = function(self){
                 measure <- 'outDegree'
                 igraph::centralize(
@@ -483,7 +483,7 @@ DirectedGraph <- R6::R6Class(
                     , normalized = TRUE
                 )
             }
-            
+
             , graphInDegree = function(self){
                 measure <- 'inDegree'
                 igraph::centralize(
@@ -496,7 +496,7 @@ DirectedGraph <- R6::R6Class(
                     , normalized = TRUE
                 )
             }
-            
+
             , graphOutCloseness = function(self){
                 measure <- 'outCloseness'
                 igraph::centralize(
@@ -507,7 +507,7 @@ DirectedGraph <- R6::R6Class(
                     , normalized = TRUE
                 )
             }
-            
+
             , graphInCloseness = function(self){
                 measure <- 'inCloseness'
                 igraph::centralize(
@@ -518,7 +518,7 @@ DirectedGraph <- R6::R6Class(
                     , normalized = TRUE
                 )
             }
-            
+
             , graphBetweenness = function(self){
                 measure <- 'betweenness'
                 igraph::centralize(
@@ -529,7 +529,7 @@ DirectedGraph <- R6::R6Class(
                     , normalized = TRUE
                 )
             }
-            
+
         ) # /graph_measures_functions
     ) # /private
 )
@@ -607,4 +607,3 @@ DirectedGraph <- R6::R6Class(
 #'     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
 #'     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
 #' }
-NULL


### PR DESCRIPTION
… one non-Integer values. Right now those columns are betweenness and pageRank. Resolves issue #228