### PR TITLE
ensure inheritanceDT is nonempty before doing comparison.  Fixes #256

### DIFF
--- a/R/FunctionReporter.R
+++ b/R/FunctionReporter.R
@@ -563,7 +563,7 @@ FunctionReporter <- R6::R6Class(
     # Not not matched, try parent if there is one and it is in package
     if (is.na(out)
         && inheritanceDT[CLASS_NAME == class_name
-                         , !is.na(PARENT_NAME) && PARENT_IN_PKG]) {
+                         , .N > 0 && !is.na(PARENT_NAME) && PARENT_IN_PKG]) {
         out <- .match_R6_class_methods(
             symbol_name
             , inheritanceDT[CLASS_NAME == class_name, PARENT_NAME]
@@ -604,7 +604,7 @@ FunctionReporter <- R6::R6Class(
     # If not matched, try parent if there is one and it is in package
     if (is.na(out)
         && inheritanceDT[CLASS_NAME == parent_name
-                         , !is.na(PARENT_NAME) && PARENT_IN_PKG]) {
+                         , .N > 0 && !is.na(PARENT_NAME) && PARENT_IN_PKG]) {
         out <- .match_R6_super_methods(
             method_name
             , inheritanceDT[CLASS_NAME == parent_name, PARENT_NAME]


### PR DESCRIPTION
Just added a simple row count check before comparing data table values.   Otherwise the result of the `data.table` command is `NA`