### PR TITLE
[docs] updated language about the maturity of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version-last-release/pkgnet)](https://cran.r-project.org/package=pkgnet) [![CRAN\_Download\_Badge](https://cranlogs.r-pkg.org/badges/grand-total/pkgnet)](https://cran.r-project.org/package=pkgnet) [![Build Status](https://img.shields.io/travis/uptake/pkgnet.svg?label=build&logo=travis&branch=master)](https://travis-ci.org/uptake/pkgnet)
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/github/uptake/pkgnet?branch=master&svg=true)](https://ci.appveyor.com/project/jameslamb/pkgnet)
 [![codecov](https://codecov.io/gh/uptake/pkgnet/branch/master/graph/badge.svg)](https://codecov.io/gh/uptake/pkgnet) 
-![Lifecycle badge](https://img.shields.io/badge/lifecycle-maturing-blue.svg)
+[![Lifecycle badge](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://www.tidyverse.org/lifecycle/)
 
 ## Introduction
 
@@ -20,7 +20,6 @@
 2. [Installation](#installation)
 3. [Usage Examples](#examples)
 4. [How to Contribute](#contributing)
-5. [Next Steps](#nextsteps)
 
 ## How it Works <a name="howitworks"></a>
 
@@ -48,7 +47,3 @@ result <- CreatePackageReport('ggplot2')
 To report bugs, request features, or ask questions about the structure of the code, please [open an issue](https://github.com/uptake/pkgnet/issues).
 
 If you'd like to contribute to the project, please [open a pull request](https://github.com/uptake/pkgnet/pulls). PRs should follow the project's [contribution guidelines](https://github.com/uptake/pkgnet/blob/master/CONTRIBUTING.md).
-
-## Next Steps <a name="nextsteps"></a>
-
-This is a fairly new project and, as the version number indicates, should be regarded as a work in progress.


### PR DESCRIPTION
I think `pkgnet` has been around and in use long enough for us to remove the text in the README saying "this is a fairly new project". In this PR, I propose removing that language and making the tidyverse lifecycle badge a link to [the page explaining what "maturing" means](https://www.tidyverse.org/lifecycle/).