### PR TITLE
[ci] remove devtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,18 @@ os:
   - linux
   - osx
 
-before_install:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm &&
+before_install: |
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew install llvm &&
     export PATH="/usr/local/opt/llvm/bin:$PATH" &&
     export LDFLAGS="-L/usr/local/opt/llvm/lib" &&
-    export CFLAGS="-I/usr/local/opt/llvm/include"; fi
-- Rscript -e "install.packages('roxygen2', repos = 'http://cran.rstudio.org')"
-- Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.org')"
+    export CFLAGS="-I/usr/local/opt/llvm/include";
+  fi
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    Rscript -e "options(install.packages.check.source = 'no'); install.packages('roxygen2', type = 'binary', repos = 'http://cran.rstudio.org')"
+  else
+    Rscript -e "install.packages('roxygen2', repos = 'http://cran.rstudio.org')"
+  fi
 
 after_success:
     - cat "${RCHECK_DIR}/tests/testthat.Rout"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,7 +293,7 @@ Change the `Version:` field in `DESCRIPTION` to the official version you want on
 Rebuild the documentation by running:
 
 ```
-Rscript -e "devtools::document()"
+Rscript -e "roxygen2::roxygenize()"
 Rscript -e "install.packages('pkgdown', repos = 'cran.rstudio.com')"
 Rscript -e "pkgdown::build_site()"
 ```
@@ -346,7 +346,7 @@ Once the submission is accepted, great! Update `cran-comments.md` and merge the 
 
 ### Create a Release on GitHub
 
-We use [the releases section](https://github.com/uptake/pkgnet/releases) in the repo to categorize certain important commits as release checkpoints. This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `devtools::install_github()` for old versions.
+We use [the releases section](https://github.com/uptake/pkgnet/releases) in the repo to categorize certain important commits as release checkpoints. This makes it easier for developers to associate changes in the source code with the release history on CRAN, and enables features like `remotes::install_github()` for old versions.
 
 Navigate to https://github.com/uptake/pkgnet/releases/new. Click the drop down in the "target" section, then click "recent commits". Choose the latest commit for the release PR you just merged. This will automatically create a [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging) on that commit and tell Github which revision to build when people ask for a given release.
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,6 @@ Imports:
     tools,
     visNetwork
 Suggests:
-    devtools,
     ggplot2,
     testthat,
     webshot,

--- a/vignettes/pkgnet-intro.Rmd
+++ b/vignettes/pkgnet-intro.Rmd
@@ -281,7 +281,8 @@ With the reports and objects produced by `pkgnet` by default, there is plenty to
      
 In this section, let's examine a larger R package, such as [lubridate](http://lubridate.tidyverse.org/).
        
-If you would like to follow along with the examples in this section, run these commands in your terminal to download and install `lubridate`^[Examples from version 1.7.3 of Lubridate].  
+If you would like to follow along with the examples in this section, run these commands in your terminal to download and install `lubridate`^[Examples from version 1.7.3 of Lubridate].
+
 ```{r bashText, engine='bash', eval=FALSE}
 # Create a temporary workspace
 mkdir -p ~/pkgnet_example && cd ~/pkgnet_example
@@ -294,7 +295,7 @@ cd lubridate
 git reset --hard 9797d69abe1574dd89310c834e52d358137669b8
 
 # Install it
-Rscript -e "devtools::install()"
+R CMD install .
 ```
 
 ## Coverage of Most Depended-on Functions

--- a/vignettes/publishing-reports.Rmd
+++ b/vignettes/publishing-reports.Rmd
@@ -32,7 +32,7 @@ CreatePackageVignette()
 
 If this is your first R Markdown vignette for your package, you'll want to add `VignetteBuilder: knitr` to your DESCRIPTION file and both `knitr` and `rmarkdown` as `Suggests` dependencies. You'll also need to install the knitr and rmarkdown packages if you haven't already. 
 
-The R Markdown file generated in this way will be built when you use `R CMD build` to create your package tarball. That means anyone installing your package will have it available, and it will also be available through CRAN if you choose to publish your package. You can preview what it will look like with `devtools::build_vignettes`. If you use pkgdown, it will also be built into an article when you use `pkgdown::build_site()`. 
+The R Markdown file generated in this way will be built when you use `R CMD build` to create your package tarball. That means anyone installing your package will have it available, and it will also be available through CRAN if you choose to publish your package. You can preview what it will look like with `devtools::build_vignettes()`. If you use pkgdown, it will also be built into an article when you use `pkgdown::build_site()`. 
 
 You can check out our [example for pkgnet](https://uptake.github.io/pkgnet-gallery/exhibits/pkgnet-vignette/pkgnet-vignette.html) to see what one looks like (it's actually slightly customized---we used the `pkg_reporters` parameter). 
 


### PR DESCRIPTION
This pull request proposes two changes to speed up this project's CI:

* not installing `devtools`
* preferring precompiled binaries on Mac