### PR TITLE
removed redundant colons from docs (#284)

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -28,26 +28,26 @@
 #' }
 #' @section Public Fields:
 #' \describe{
-#'     \item{\bold{\code{nodes}}}{: a data.table, containing information about
+#'     \item{\bold{\code{nodes}}}{a data.table, containing information about
 #'        the nodes of the network the reporter is analyzing. The \code{node}
 #'        column acts the identifier. Read-only.
 #'     }
-#'     \item{\bold{\code{edges}}}{: a data.table, containing information about
+#'     \item{\bold{\code{edges}}}{a data.table, containing information about
 #'        the edge connections of the network the reporter is analyzing. Each
 #'        row is one edge, and the columns \code{SOURCE} and \code{TARGET}
 #'        specify the node identifiers. Read-only.
 #'     }
-#'     \item{\bold{\code{network_measures}}}{: a list, containing any measures
+#'     \item{\bold{\code{network_measures}}}{a list, containing any measures
 #'        of the network calculated by the reporter. Read-only.
 #'     }
-#'     \item{\bold{\code{pkg_graph}}}{: a graph model object. See \link{DirectedGraph}
+#'     \item{\bold{\code{pkg_graph}}}{a graph model object. See \link{DirectedGraph}
 #'        for additional documentation. Read-only.
 #'     }
-#'     \item{\bold{\code{graph_viz}}}{: a graph visualization object. A
+#'     \item{\bold{\code{graph_viz}}}{a graph visualization object. A
 #'        \code{\link[visNetwork:visNetwork]{visNetwork::visNetwork}} object.
 #'        Read-only.
 #'     }
-#'     \item{\bold{\code{layout_type}}}{: a character string, the current layout
+#'     \item{\bold{\code{layout_type}}}{a character string, the current layout
 #'        type for the graph visualization. Can be assigned a new valid layout
 #'        type value. Use use
 #'        \code{grep("^layout_\\\\S", getNamespaceExports("igraph"), value = TRUE)}

--- a/R/AbstractPackageReporter.R
+++ b/R/AbstractPackageReporter.R
@@ -70,10 +70,10 @@
 #'
 #' @section Public Fields:
 #' \describe{
-#'     \item{\bold{\code{pkg_name}}}{: character string, name of set package.
+#'     \item{\bold{\code{pkg_name}}}{character string, name of set package.
 #'         Read-only.
 #'     }
-#'     \item{\bold{\code{report_markdown_path}}}{: character string, path to
+#'     \item{\bold{\code{report_markdown_path}}}{character string, path to
 #'         R Markdown template for this reporter. Read-only.
 #'     }
 #' }

--- a/R/CreatePackageReport.R
+++ b/R/CreatePackageReport.R
@@ -16,7 +16,7 @@
 #' \itemize{
 #'    \item{Initialize an instance of a package report object.}
 #'        \item{\bold{Args:}}{\itemize{
-#'            \item{\bold{\code{pkg_name}}: (character string) name of
+#'            \item{\bold{\code{pkg_name}} (character string) name of
 #'                package
 #'            }
 #'            \item{\bold{\code{pkg_path}}: (character string) optional
@@ -66,22 +66,22 @@
 #'
 #' @section Public Fields:
 #' \describe{
-#'     \item{\bold{\code{pkg_name}}}{: (character string) name of package.
+#'     \item{\bold{\code{pkg_name}}}{(character string) name of package.
 #'         Read-only.
 #'     }
-#'     \item{\bold{\code{pkg_path}}}{: (character string) path to source code of
+#'     \item{\bold{\code{pkg_path}}}{(character string) path to source code of
 #'         the package. Read-only.
 #'     }
-#'     \item{\bold{\code{report_path}}}{: (character string) path and filename
+#'     \item{\bold{\code{report_path}}}{(character string) path and filename
 #'         of output report.
 #'     }
-#'     \item{\bold{\code{SummaryReporter}}}{: instantiated pkgnet
+#'     \item{\bold{\code{SummaryReporter}}}{instantiated pkgnet
 #'         \code{\link{SummaryReporter}} object}
-#'     \item{\bold{\code{DependencyReporter}}}{: instantiated pkgnet
+#'     \item{\bold{\code{DependencyReporter}}}{instantiated pkgnet
 #'         \code{\link{DependencyReporter}} object}
-#'     \item{\bold{\code{FunctionReporter}}}{: instantiated pkgnet
+#'     \item{\bold{\code{FunctionReporter}}}{instantiated pkgnet
 #'         \code{\link{FunctionReporter}} object}
-#'     \item{\bold{\code{InheritanceReporter}}}{: instantiated pkgnet
+#'     \item{\bold{\code{InheritanceReporter}}}{instantiated pkgnet
 #'         \code{\link{InheritanceReporter}} object}
 #' }
 #'
@@ -95,7 +95,7 @@
 #'             }
 #'             \item{\bold{Args:}}{
 #'                 \itemize{
-#'                     \item{\bold{\code{deep}}: (logical) Whether to recursively
+#'                     \item{\bold{\code{deep}}(logical) Whether to recursively
 #'                     clone nested R6 objects.
 #'                  }
 #'                 }

--- a/R/GraphClasses.R
+++ b/R/GraphClasses.R
@@ -72,19 +72,19 @@
 #'
 #' @section Public Fields:
 #' \describe{
-#'     \item{\bold{\code{nodes}}}{: node data.table, read-only}
-#'     \item{\bold{\code{edges}}}{: edge data.table, read-only}
-#'     \item{\bold{\code{igraph}}}{: igraph object, read-only}
-#'     \item{\bold{\code{available_node_measures}}}{: character vector of all
+#'     \item{\bold{\code{nodes}}}{node data.table, read-only}
+#'     \item{\bold{\code{edges}}}{edge data.table, read-only}
+#'     \item{\bold{\code{igraph}}}{igraph object, read-only}
+#'     \item{\bold{\code{available_node_measures}}}{character vector of all
 #'     supported node measures. See Node Measures section below for detailed
 #'     descriptions. Read-only.}
-#'     \item{\bold{\code{available_graph_measures}}}{: character vector of all
+#'     \item{\bold{\code{available_graph_measures}}}{character vector of all
 #'     supported graph measures. See Graph Measures section below for detailed
 #'     descriptions. Read-only.}
-#'     \item{\bold{\code{default_node_measures}}}{: character vector of default
+#'     \item{\bold{\code{default_node_measures}}}{character vector of default
 #'     node measures. See Node Measures section below for detailed descriptions.
 #'     Read-only.}
-#'     \item{\bold{\code{default_graph_measures}}}{: character vector of default
+#'     \item{\bold{\code{default_graph_measures}}}{character vector of default
 #'     graph measures. See Graph Measures section below for detailed descriptions.
 #'     Read-only.}
 #' }
@@ -544,67 +544,67 @@ DirectedGraph <- R6::R6Class(
 #'    networks modeled by \link{DirectedGraph}.
 #' @section Node Measures:
 #' \describe{
-#'     \item{\bold{\code{outDegree}}}{: outdegree, the number of outward edges (tail ends).
+#'     \item{\bold{\code{outDegree}}}{outdegree, the number of outward edges (tail ends).
 #'     Calculated by \code{\link[igraph:degree]{igraph::degree}}.
 #'     [\href{https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree}{Wikipedia}]}
-#'     \item{\bold{\code{inDegree}}}{: indegree, number of inward edges (head ends).
+#'     \item{\bold{\code{inDegree}}}{indegree, number of inward edges (head ends).
 #'     Calculated by \code{\link[igraph:degree]{igraph::degree}}.
 #'     [\href{https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree}{Wikipedia}]}
-#'     \item{\bold{\code{outCloseness}}}{: closeness centrality (out), a measure of
+#'     \item{\bold{\code{outCloseness}}}{closeness centrality (out), a measure of
 #'     path lengths to other nodes along edge directions.
 #'     Calculated by \code{\link[igraph:closeness]{igraph::closeness}}.
 #'     [\href{https://en.wikipedia.org/wiki/Closeness_centrality}{Wikipedia}]}
-#'     \item{\bold{\code{inCloseness}}}{: closeness centrality (in), a measure of
+#'     \item{\bold{\code{inCloseness}}}{closeness centrality (in), a measure of
 #'     path lengths to other nodes in reverse of edge directions.
 #'     Calculated by \code{\link[igraph:closeness]{igraph::closeness}}.
 #'     [\href{https://en.wikipedia.org/wiki/Closeness_centrality}{Wikipedia}]}
-#'     \item{\bold{\code{numRecursiveDeps}}}{: number recursive dependencies, i.e., count of all nodes reachable by following edges
+#'     \item{\bold{\code{numRecursiveDeps}}}{number recursive dependencies, i.e., count of all nodes reachable by following edges
 #'     out from this node.
 #'     Calculated by \code{\link[igraph:neighborhood.size]{igraph::neighborhood.size}}.
 #'     [\href{https://en.wikipedia.org/wiki/Rooted_graph}{Wikipedia}]}
-#'     \item{\bold{\code{numRecursiveRevDeps}}}{: number of recursive reverse dependencies (dependents), i.e., count all nodes reachable by following edges
+#'     \item{\bold{\code{numRecursiveRevDeps}}}{number of recursive reverse dependencies (dependents), i.e., count all nodes reachable by following edges
 #'     into this node in reverse direction.
 #'     Calculated by \code{\link[igraph:neighborhood.size]{igraph::neighborhood.size}}.
 #'     [\href{https://en.wikipedia.org/wiki/Rooted_graph}{Wikipedia}]}
-#'     \item{\bold{\code{betweenness}}}{: betweenness centrality, a measure of
+#'     \item{\bold{\code{betweenness}}}{betweenness centrality, a measure of
 #'     the number of shortest paths in graph passing through this node
 #'     Calculated by \code{\link[igraph:betweenness]{igraph::betweenness}}.
 #'     [\href{https://en.wikipedia.org/wiki/Betweenness_centrality}{Wikipedia}]}
-#'     \item{\bold{\code{pageRank}}}{: Google PageRank.
+#'     \item{\bold{\code{pageRank}}}{Google PageRank.
 #'     Calculated by \code{\link[igraph:page_rank]{igraph::page_rank}}.
 #'     [\href{https://en.wikipedia.org/wiki/PageRank}{Wikipedia}]}
-#'     \item{\bold{\code{hubScore}}}{: hub score from Hyperlink-Induced Topic
+#'     \item{\bold{\code{hubScore}}}{hub score from Hyperlink-Induced Topic
 #'     Search (HITS) algorithm.
 #'     Calculated by \code{\link[igraph:hub_score]{igraph::hub_score}}.
 #'     [\href{https://en.wikipedia.org/wiki/HITS_algorithm}{Wikipedia}]}
-#'     \item{\bold{\code{authorityScore}}}{: authority score from
+#'     \item{\bold{\code{authorityScore}}}{authority score from
 #'     Hyperlink-Induced Topic Search (HITS) algorithm.
 #'     Calculated by \code{\link[igraph:authority_score]{igraph::authority_score}}.
 #'     [\href{https://en.wikipedia.org/wiki/HITS_algorithm}{Wikipedia}]}
 #' }
 #' @section Graph Measures:
 #' \describe{
-#'     \item{\bold{\code{graphOutDegree}}}{: graph freeman centralization for
+#'     \item{\bold{\code{graphOutDegree}}}{graph freeman centralization for
 #'     outdegree. A measure of the most central node by outdegree in relation to
 #'     all other nodes.
 #'     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
 #'     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-#'     \item{\bold{\code{graphInDegree}}}{: graph Freeman centralization for
+#'     \item{\bold{\code{graphInDegree}}}{graph Freeman centralization for
 #'     indegree. A measure of the most central node by indegree in relation to
 #'     all other nodes.
 #'     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
 #'     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-#'     \item{\bold{\code{graphOutClosness}}}{: graph Freeman centralization for
+#'     \item{\bold{\code{graphOutClosness}}}{graph Freeman centralization for
 #'     out-closeness. A measure of the most central node by out-closeness in relation to
 #'     all other nodes.
 #'     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
 #'     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-#'     \item{\bold{\code{graphInCloseness}}}{: graph Freeman centralization for
+#'     \item{\bold{\code{graphInCloseness}}}{graph Freeman centralization for
 #'     outdegree. A measure of the most central node by outdegree in relation to
 #'     all other nodes.
 #'     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
 #'     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-#'     \item{\bold{\code{graphBetweennness}}}{: graph Freeman centralization for
+#'     \item{\bold{\code{graphBetweennness}}}{graph Freeman centralization for
 #'     betweenness A measure of the most central node by betweenness in relation to
 #'     all other nodes.
 #'     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.

--- a/R/pkgnet.R
+++ b/R/pkgnet.R
@@ -60,17 +60,17 @@ globalVariables(c('.'
 #'   package. The currently available reporters are:
 #'
 #'   \describe{
-#'     \item{\bold{\code{\link{DependencyReporter}}}}{: analyze the recursive
+#'     \item{\bold{\code{\link{DependencyReporter}}}}{analyze the recursive
 #'        network of packages that the subject package depends on.
 #'     }
-#'     \item{\bold{\code{\link{FunctionReporter}}}}{: analyze the network of
+#'     \item{\bold{\code{\link{FunctionReporter}}}}{analyze the network of
 #'        interdependencies of the functions defined in the subject package
 #'     }
-#'     \item{\bold{\code{\link{InheritanceReporter}}}}{: analyze the class
+#'     \item{\bold{\code{\link{InheritanceReporter}}}}{analyze the class
 #'        inheritance trees for subject packages that use object-oriented
 #'        programming.
 #'     }
-#'     \item{\bold{\code{\link{SummaryReporter}}}}{: get an overview of the
+#'     \item{\bold{\code{\link{SummaryReporter}}}}{get an overview of the
 #'        subject package through its DESCRIPTION file.
 #'     }
 #'   }

--- a/man/DependencyReporter.Rd
+++ b/man/DependencyReporter.Rd
@@ -97,36 +97,36 @@ This reporter looks at the recursive network of its dependencies
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{pkg_name}}}{: character string, name of set package.
+    \item{\bold{\code{pkg_name}}}{character string, name of set package.
         Read-only.
     }
-    \item{\bold{\code{report_markdown_path}}}{: character string, path to
+    \item{\bold{\code{report_markdown_path}}}{character string, path to
         R Markdown template for this reporter. Read-only.
     }
 }
 
 
 \describe{
-    \item{\bold{\code{nodes}}}{: a data.table, containing information about
+    \item{\bold{\code{nodes}}}{a data.table, containing information about
        the nodes of the network the reporter is analyzing. The \code{node}
        column acts the identifier. Read-only.
     }
-    \item{\bold{\code{edges}}}{: a data.table, containing information about
+    \item{\bold{\code{edges}}}{a data.table, containing information about
        the edge connections of the network the reporter is analyzing. Each
        row is one edge, and the columns \code{SOURCE} and \code{TARGET}
        specify the node identifiers. Read-only.
     }
-    \item{\bold{\code{network_measures}}}{: a list, containing any measures
+    \item{\bold{\code{network_measures}}}{a list, containing any measures
        of the network calculated by the reporter. Read-only.
     }
-    \item{\bold{\code{pkg_graph}}}{: a graph model object. See \link{DirectedGraph}
+    \item{\bold{\code{pkg_graph}}}{a graph model object. See \link{DirectedGraph}
        for additional documentation. Read-only.
     }
-    \item{\bold{\code{graph_viz}}}{: a graph visualization object. A
+    \item{\bold{\code{graph_viz}}}{a graph visualization object. A
        \code{\link[visNetwork:visNetwork]{visNetwork::visNetwork}} object.
        Read-only.
     }
-    \item{\bold{\code{layout_type}}}{: a character string, the current layout
+    \item{\bold{\code{layout_type}}}{a character string, the current layout
        type for the graph visualization. Can be assigned a new valid layout
        type value. Use use
        \code{grep("^layout_\\\\S", getNamespaceExports("igraph"), value = TRUE)}

--- a/man/DirectedGraph.Rd
+++ b/man/DirectedGraph.Rd
@@ -62,19 +62,19 @@ R6 class defining a directed graph model for representing a
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{nodes}}}{: node data.table, read-only}
-    \item{\bold{\code{edges}}}{: edge data.table, read-only}
-    \item{\bold{\code{igraph}}}{: igraph object, read-only}
-    \item{\bold{\code{available_node_measures}}}{: character vector of all
+    \item{\bold{\code{nodes}}}{node data.table, read-only}
+    \item{\bold{\code{edges}}}{edge data.table, read-only}
+    \item{\bold{\code{igraph}}}{igraph object, read-only}
+    \item{\bold{\code{available_node_measures}}}{character vector of all
     supported node measures. See Node Measures section below for detailed
     descriptions. Read-only.}
-    \item{\bold{\code{available_graph_measures}}}{: character vector of all
+    \item{\bold{\code{available_graph_measures}}}{character vector of all
     supported graph measures. See Graph Measures section below for detailed
     descriptions. Read-only.}
-    \item{\bold{\code{default_node_measures}}}{: character vector of default
+    \item{\bold{\code{default_node_measures}}}{character vector of default
     node measures. See Node Measures section below for detailed descriptions.
     Read-only.}
-    \item{\bold{\code{default_graph_measures}}}{: character vector of default
+    \item{\bold{\code{default_graph_measures}}}{character vector of default
     graph measures. See Graph Measures section below for detailed descriptions.
     Read-only.}
 }
@@ -83,40 +83,40 @@ R6 class defining a directed graph model for representing a
 \section{Node Measures}{
 
 \describe{
-    \item{\bold{\code{outDegree}}}{: outdegree, the number of outward edges (tail ends).
+    \item{\bold{\code{outDegree}}}{outdegree, the number of outward edges (tail ends).
     Calculated by \code{\link[igraph:degree]{igraph::degree}}.
     [\href{https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree}{Wikipedia}]}
-    \item{\bold{\code{inDegree}}}{: indegree, number of inward edges (head ends).
+    \item{\bold{\code{inDegree}}}{indegree, number of inward edges (head ends).
     Calculated by \code{\link[igraph:degree]{igraph::degree}}.
     [\href{https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree}{Wikipedia}]}
-    \item{\bold{\code{outCloseness}}}{: closeness centrality (out), a measure of
+    \item{\bold{\code{outCloseness}}}{closeness centrality (out), a measure of
     path lengths to other nodes along edge directions.
     Calculated by \code{\link[igraph:closeness]{igraph::closeness}}.
     [\href{https://en.wikipedia.org/wiki/Closeness_centrality}{Wikipedia}]}
-    \item{\bold{\code{inCloseness}}}{: closeness centrality (in), a measure of
+    \item{\bold{\code{inCloseness}}}{closeness centrality (in), a measure of
     path lengths to other nodes in reverse of edge directions.
     Calculated by \code{\link[igraph:closeness]{igraph::closeness}}.
     [\href{https://en.wikipedia.org/wiki/Closeness_centrality}{Wikipedia}]}
-    \item{\bold{\code{numRecursiveDeps}}}{: number recursive dependencies, i.e., count of all nodes reachable by following edges
+    \item{\bold{\code{numRecursiveDeps}}}{number recursive dependencies, i.e., count of all nodes reachable by following edges
     out from this node.
     Calculated by \code{\link[igraph:neighborhood.size]{igraph::neighborhood.size}}.
     [\href{https://en.wikipedia.org/wiki/Rooted_graph}{Wikipedia}]}
-    \item{\bold{\code{numRecursiveRevDeps}}}{: number of recursive reverse dependencies (dependents), i.e., count all nodes reachable by following edges
+    \item{\bold{\code{numRecursiveRevDeps}}}{number of recursive reverse dependencies (dependents), i.e., count all nodes reachable by following edges
     into this node in reverse direction.
     Calculated by \code{\link[igraph:neighborhood.size]{igraph::neighborhood.size}}.
     [\href{https://en.wikipedia.org/wiki/Rooted_graph}{Wikipedia}]}
-    \item{\bold{\code{betweenness}}}{: betweenness centrality, a measure of
+    \item{\bold{\code{betweenness}}}{betweenness centrality, a measure of
     the number of shortest paths in graph passing through this node
     Calculated by \code{\link[igraph:betweenness]{igraph::betweenness}}.
     [\href{https://en.wikipedia.org/wiki/Betweenness_centrality}{Wikipedia}]}
-    \item{\bold{\code{pageRank}}}{: Google PageRank.
+    \item{\bold{\code{pageRank}}}{Google PageRank.
     Calculated by \code{\link[igraph:page_rank]{igraph::page_rank}}.
     [\href{https://en.wikipedia.org/wiki/PageRank}{Wikipedia}]}
-    \item{\bold{\code{hubScore}}}{: hub score from Hyperlink-Induced Topic
+    \item{\bold{\code{hubScore}}}{hub score from Hyperlink-Induced Topic
     Search (HITS) algorithm.
     Calculated by \code{\link[igraph:hub_score]{igraph::hub_score}}.
     [\href{https://en.wikipedia.org/wiki/HITS_algorithm}{Wikipedia}]}
-    \item{\bold{\code{authorityScore}}}{: authority score from
+    \item{\bold{\code{authorityScore}}}{authority score from
     Hyperlink-Induced Topic Search (HITS) algorithm.
     Calculated by \code{\link[igraph:authority_score]{igraph::authority_score}}.
     [\href{https://en.wikipedia.org/wiki/HITS_algorithm}{Wikipedia}]}
@@ -126,27 +126,27 @@ R6 class defining a directed graph model for representing a
 \section{Graph Measures}{
 
 \describe{
-    \item{\bold{\code{graphOutDegree}}}{: graph freeman centralization for
+    \item{\bold{\code{graphOutDegree}}}{graph freeman centralization for
     outdegree. A measure of the most central node by outdegree in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphInDegree}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphInDegree}}}{graph Freeman centralization for
     indegree. A measure of the most central node by indegree in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphOutClosness}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphOutClosness}}}{graph Freeman centralization for
     out-closeness. A measure of the most central node by out-closeness in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphInCloseness}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphInCloseness}}}{graph Freeman centralization for
     outdegree. A measure of the most central node by outdegree in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphBetweennness}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphBetweennness}}}{graph Freeman centralization for
     betweenness A measure of the most central node by betweenness in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.

--- a/man/DirectedGraphMeasures.Rd
+++ b/man/DirectedGraphMeasures.Rd
@@ -10,40 +10,40 @@ Descriptions for all available node and graph measures for
 \section{Node Measures}{
 
 \describe{
-    \item{\bold{\code{outDegree}}}{: outdegree, the number of outward edges (tail ends).
+    \item{\bold{\code{outDegree}}}{outdegree, the number of outward edges (tail ends).
     Calculated by \code{\link[igraph:degree]{igraph::degree}}.
     [\href{https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree}{Wikipedia}]}
-    \item{\bold{\code{inDegree}}}{: indegree, number of inward edges (head ends).
+    \item{\bold{\code{inDegree}}}{indegree, number of inward edges (head ends).
     Calculated by \code{\link[igraph:degree]{igraph::degree}}.
     [\href{https://en.wikipedia.org/wiki/Directed_graph#Indegree_and_outdegree}{Wikipedia}]}
-    \item{\bold{\code{outCloseness}}}{: closeness centrality (out), a measure of
+    \item{\bold{\code{outCloseness}}}{closeness centrality (out), a measure of
     path lengths to other nodes along edge directions.
     Calculated by \code{\link[igraph:closeness]{igraph::closeness}}.
     [\href{https://en.wikipedia.org/wiki/Closeness_centrality}{Wikipedia}]}
-    \item{\bold{\code{inCloseness}}}{: closeness centrality (in), a measure of
+    \item{\bold{\code{inCloseness}}}{closeness centrality (in), a measure of
     path lengths to other nodes in reverse of edge directions.
     Calculated by \code{\link[igraph:closeness]{igraph::closeness}}.
     [\href{https://en.wikipedia.org/wiki/Closeness_centrality}{Wikipedia}]}
-    \item{\bold{\code{numRecursiveDeps}}}{: number recursive dependencies, i.e., count of all nodes reachable by following edges
+    \item{\bold{\code{numRecursiveDeps}}}{number recursive dependencies, i.e., count of all nodes reachable by following edges
     out from this node.
     Calculated by \code{\link[igraph:neighborhood.size]{igraph::neighborhood.size}}.
     [\href{https://en.wikipedia.org/wiki/Rooted_graph}{Wikipedia}]}
-    \item{\bold{\code{numRecursiveRevDeps}}}{: number of recursive reverse dependencies (dependents), i.e., count all nodes reachable by following edges
+    \item{\bold{\code{numRecursiveRevDeps}}}{number of recursive reverse dependencies (dependents), i.e., count all nodes reachable by following edges
     into this node in reverse direction.
     Calculated by \code{\link[igraph:neighborhood.size]{igraph::neighborhood.size}}.
     [\href{https://en.wikipedia.org/wiki/Rooted_graph}{Wikipedia}]}
-    \item{\bold{\code{betweenness}}}{: betweenness centrality, a measure of
+    \item{\bold{\code{betweenness}}}{betweenness centrality, a measure of
     the number of shortest paths in graph passing through this node
     Calculated by \code{\link[igraph:betweenness]{igraph::betweenness}}.
     [\href{https://en.wikipedia.org/wiki/Betweenness_centrality}{Wikipedia}]}
-    \item{\bold{\code{pageRank}}}{: Google PageRank.
+    \item{\bold{\code{pageRank}}}{Google PageRank.
     Calculated by \code{\link[igraph:page_rank]{igraph::page_rank}}.
     [\href{https://en.wikipedia.org/wiki/PageRank}{Wikipedia}]}
-    \item{\bold{\code{hubScore}}}{: hub score from Hyperlink-Induced Topic
+    \item{\bold{\code{hubScore}}}{hub score from Hyperlink-Induced Topic
     Search (HITS) algorithm.
     Calculated by \code{\link[igraph:hub_score]{igraph::hub_score}}.
     [\href{https://en.wikipedia.org/wiki/HITS_algorithm}{Wikipedia}]}
-    \item{\bold{\code{authorityScore}}}{: authority score from
+    \item{\bold{\code{authorityScore}}}{authority score from
     Hyperlink-Induced Topic Search (HITS) algorithm.
     Calculated by \code{\link[igraph:authority_score]{igraph::authority_score}}.
     [\href{https://en.wikipedia.org/wiki/HITS_algorithm}{Wikipedia}]}
@@ -53,27 +53,27 @@ Descriptions for all available node and graph measures for
 \section{Graph Measures}{
 
 \describe{
-    \item{\bold{\code{graphOutDegree}}}{: graph freeman centralization for
+    \item{\bold{\code{graphOutDegree}}}{graph freeman centralization for
     outdegree. A measure of the most central node by outdegree in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphInDegree}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphInDegree}}}{graph Freeman centralization for
     indegree. A measure of the most central node by indegree in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphOutClosness}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphOutClosness}}}{graph Freeman centralization for
     out-closeness. A measure of the most central node by out-closeness in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphInCloseness}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphInCloseness}}}{graph Freeman centralization for
     outdegree. A measure of the most central node by outdegree in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.
     [\href{https://en.wikipedia.org/wiki/Centrality#Freeman_centralization}{Wikipedia}]}
-    \item{\bold{\code{graphBetweennness}}}{: graph Freeman centralization for
+    \item{\bold{\code{graphBetweennness}}}{graph Freeman centralization for
     betweenness A measure of the most central node by betweenness in relation to
     all other nodes.
     Calculated by \code{\link[igraph:centralize]{igraph::centralize}}.

--- a/man/FunctionReporter.Rd
+++ b/man/FunctionReporter.Rd
@@ -139,36 +139,36 @@ This reporter looks at the network of interdependencies of its
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{pkg_name}}}{: character string, name of set package.
+    \item{\bold{\code{pkg_name}}}{character string, name of set package.
         Read-only.
     }
-    \item{\bold{\code{report_markdown_path}}}{: character string, path to
+    \item{\bold{\code{report_markdown_path}}}{character string, path to
         R Markdown template for this reporter. Read-only.
     }
 }
 
 
 \describe{
-    \item{\bold{\code{nodes}}}{: a data.table, containing information about
+    \item{\bold{\code{nodes}}}{a data.table, containing information about
        the nodes of the network the reporter is analyzing. The \code{node}
        column acts the identifier. Read-only.
     }
-    \item{\bold{\code{edges}}}{: a data.table, containing information about
+    \item{\bold{\code{edges}}}{a data.table, containing information about
        the edge connections of the network the reporter is analyzing. Each
        row is one edge, and the columns \code{SOURCE} and \code{TARGET}
        specify the node identifiers. Read-only.
     }
-    \item{\bold{\code{network_measures}}}{: a list, containing any measures
+    \item{\bold{\code{network_measures}}}{a list, containing any measures
        of the network calculated by the reporter. Read-only.
     }
-    \item{\bold{\code{pkg_graph}}}{: a graph model object. See \link{DirectedGraph}
+    \item{\bold{\code{pkg_graph}}}{a graph model object. See \link{DirectedGraph}
        for additional documentation. Read-only.
     }
-    \item{\bold{\code{graph_viz}}}{: a graph visualization object. A
+    \item{\bold{\code{graph_viz}}}{a graph visualization object. A
        \code{\link[visNetwork:visNetwork]{visNetwork::visNetwork}} object.
        Read-only.
     }
-    \item{\bold{\code{layout_type}}}{: a character string, the current layout
+    \item{\bold{\code{layout_type}}}{a character string, the current layout
        type for the graph visualization. Can be assigned a new valid layout
        type value. Use use
        \code{grep("^layout_\\\\S", getNamespaceExports("igraph"), value = TRUE)}

--- a/man/GraphClasses.Rd
+++ b/man/GraphClasses.Rd
@@ -79,19 +79,19 @@ pkgnet uses R6 classes to define and encapsulate the graph
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{nodes}}}{: node data.table, read-only}
-    \item{\bold{\code{edges}}}{: edge data.table, read-only}
-    \item{\bold{\code{igraph}}}{: igraph object, read-only}
-    \item{\bold{\code{available_node_measures}}}{: character vector of all
+    \item{\bold{\code{nodes}}}{node data.table, read-only}
+    \item{\bold{\code{edges}}}{edge data.table, read-only}
+    \item{\bold{\code{igraph}}}{igraph object, read-only}
+    \item{\bold{\code{available_node_measures}}}{character vector of all
     supported node measures. See Node Measures section below for detailed
     descriptions. Read-only.}
-    \item{\bold{\code{available_graph_measures}}}{: character vector of all
+    \item{\bold{\code{available_graph_measures}}}{character vector of all
     supported graph measures. See Graph Measures section below for detailed
     descriptions. Read-only.}
-    \item{\bold{\code{default_node_measures}}}{: character vector of default
+    \item{\bold{\code{default_node_measures}}}{character vector of default
     node measures. See Node Measures section below for detailed descriptions.
     Read-only.}
-    \item{\bold{\code{default_graph_measures}}}{: character vector of default
+    \item{\bold{\code{default_graph_measures}}}{character vector of default
     graph measures. See Graph Measures section below for detailed descriptions.
     Read-only.}
 }

--- a/man/InheritanceReporter.Rd
+++ b/man/InheritanceReporter.Rd
@@ -125,36 +125,36 @@ Note the following details about class naming:
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{pkg_name}}}{: character string, name of set package.
+    \item{\bold{\code{pkg_name}}}{character string, name of set package.
         Read-only.
     }
-    \item{\bold{\code{report_markdown_path}}}{: character string, path to
+    \item{\bold{\code{report_markdown_path}}}{character string, path to
         R Markdown template for this reporter. Read-only.
     }
 }
 
 
 \describe{
-    \item{\bold{\code{nodes}}}{: a data.table, containing information about
+    \item{\bold{\code{nodes}}}{a data.table, containing information about
        the nodes of the network the reporter is analyzing. The \code{node}
        column acts the identifier. Read-only.
     }
-    \item{\bold{\code{edges}}}{: a data.table, containing information about
+    \item{\bold{\code{edges}}}{a data.table, containing information about
        the edge connections of the network the reporter is analyzing. Each
        row is one edge, and the columns \code{SOURCE} and \code{TARGET}
        specify the node identifiers. Read-only.
     }
-    \item{\bold{\code{network_measures}}}{: a list, containing any measures
+    \item{\bold{\code{network_measures}}}{a list, containing any measures
        of the network calculated by the reporter. Read-only.
     }
-    \item{\bold{\code{pkg_graph}}}{: a graph model object. See \link{DirectedGraph}
+    \item{\bold{\code{pkg_graph}}}{a graph model object. See \link{DirectedGraph}
        for additional documentation. Read-only.
     }
-    \item{\bold{\code{graph_viz}}}{: a graph visualization object. A
+    \item{\bold{\code{graph_viz}}}{a graph visualization object. A
        \code{\link[visNetwork:visNetwork]{visNetwork::visNetwork}} object.
        Read-only.
     }
-    \item{\bold{\code{layout_type}}}{: a character string, the current layout
+    \item{\bold{\code{layout_type}}}{a character string, the current layout
        type for the graph visualization. Can be assigned a new valid layout
        type value. Use use
        \code{grep("^layout_\\\\S", getNamespaceExports("igraph"), value = TRUE)}

--- a/man/NetworkReporters.Rd
+++ b/man/NetworkReporters.Rd
@@ -34,26 +34,26 @@
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{nodes}}}{: a data.table, containing information about
+    \item{\bold{\code{nodes}}}{a data.table, containing information about
        the nodes of the network the reporter is analyzing. The \code{node}
        column acts the identifier. Read-only.
     }
-    \item{\bold{\code{edges}}}{: a data.table, containing information about
+    \item{\bold{\code{edges}}}{a data.table, containing information about
        the edge connections of the network the reporter is analyzing. Each
        row is one edge, and the columns \code{SOURCE} and \code{TARGET}
        specify the node identifiers. Read-only.
     }
-    \item{\bold{\code{network_measures}}}{: a list, containing any measures
+    \item{\bold{\code{network_measures}}}{a list, containing any measures
        of the network calculated by the reporter. Read-only.
     }
-    \item{\bold{\code{pkg_graph}}}{: a graph model object. See \link{DirectedGraph}
+    \item{\bold{\code{pkg_graph}}}{a graph model object. See \link{DirectedGraph}
        for additional documentation. Read-only.
     }
-    \item{\bold{\code{graph_viz}}}{: a graph visualization object. A
+    \item{\bold{\code{graph_viz}}}{a graph visualization object. A
        \code{\link[visNetwork:visNetwork]{visNetwork::visNetwork}} object.
        Read-only.
     }
-    \item{\bold{\code{layout_type}}}{: a character string, the current layout
+    \item{\bold{\code{layout_type}}}{a character string, the current layout
        type for the graph visualization. Can be assigned a new valid layout
        type value. Use use
        \code{grep("^layout_\\\\S", getNamespaceExports("igraph"), value = TRUE)}

--- a/man/PackageReport.Rd
+++ b/man/PackageReport.Rd
@@ -21,7 +21,7 @@ pkgnet compiles one or more package reporters into a package
 \itemize{
    \item{Initialize an instance of a package report object.}
        \item{\bold{Args:}}{\itemize{
-           \item{\bold{\code{pkg_name}}: (character string) name of
+           \item{\bold{\code{pkg_name}} (character string) name of
                package
            }
            \item{\bold{\code{pkg_path}}: (character string) optional
@@ -75,22 +75,22 @@ pkgnet compiles one or more package reporters into a package
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{pkg_name}}}{: (character string) name of package.
+    \item{\bold{\code{pkg_name}}}{(character string) name of package.
         Read-only.
     }
-    \item{\bold{\code{pkg_path}}}{: (character string) path to source code of
+    \item{\bold{\code{pkg_path}}}{(character string) path to source code of
         the package. Read-only.
     }
-    \item{\bold{\code{report_path}}}{: (character string) path and filename
+    \item{\bold{\code{report_path}}}{(character string) path and filename
         of output report.
     }
-    \item{\bold{\code{SummaryReporter}}}{: instantiated pkgnet
+    \item{\bold{\code{SummaryReporter}}}{instantiated pkgnet
         \code{\link{SummaryReporter}} object}
-    \item{\bold{\code{DependencyReporter}}}{: instantiated pkgnet
+    \item{\bold{\code{DependencyReporter}}}{instantiated pkgnet
         \code{\link{DependencyReporter}} object}
-    \item{\bold{\code{FunctionReporter}}}{: instantiated pkgnet
+    \item{\bold{\code{FunctionReporter}}}{instantiated pkgnet
         \code{\link{FunctionReporter}} object}
-    \item{\bold{\code{InheritanceReporter}}}{: instantiated pkgnet
+    \item{\bold{\code{InheritanceReporter}}}{instantiated pkgnet
         \code{\link{InheritanceReporter}} object}
 }
 }
@@ -106,7 +106,7 @@ pkgnet compiles one or more package reporters into a package
             }
             \item{\bold{Args:}}{
                 \itemize{
-                    \item{\bold{\code{deep}}: (logical) Whether to recursively
+                    \item{\bold{\code{deep}}(logical) Whether to recursively
                     clone nested R6 objects.
                  }
                 }

--- a/man/PackageReporters.Rd
+++ b/man/PackageReporters.Rd
@@ -78,10 +78,10 @@ pkgnet defines several package reporter R6 classes that analyze
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{pkg_name}}}{: character string, name of set package.
+    \item{\bold{\code{pkg_name}}}{character string, name of set package.
         Read-only.
     }
-    \item{\bold{\code{report_markdown_path}}}{: character string, path to
+    \item{\bold{\code{report_markdown_path}}}{character string, path to
         R Markdown template for this reporter. Read-only.
     }
 }

--- a/man/SummaryReporter.Rd
+++ b/man/SummaryReporter.Rd
@@ -79,10 +79,10 @@ This reporter provides a high-level overview of a package via
 \section{Public Fields}{
 
 \describe{
-    \item{\bold{\code{pkg_name}}}{: character string, name of set package.
+    \item{\bold{\code{pkg_name}}}{character string, name of set package.
         Read-only.
     }
-    \item{\bold{\code{report_markdown_path}}}{: character string, path to
+    \item{\bold{\code{report_markdown_path}}}{character string, path to
         R Markdown template for this reporter. Read-only.
     }
 }

--- a/man/pkgnet-package.Rd
+++ b/man/pkgnet-package.Rd
@@ -33,17 +33,17 @@ R packages can be complex bodies of code and functionality with
   package. The currently available reporters are:
 
   \describe{
-    \item{\bold{\code{\link{DependencyReporter}}}}{: analyze the recursive
+    \item{\bold{\code{\link{DependencyReporter}}}}{analyze the recursive
        network of packages that the subject package depends on.
     }
-    \item{\bold{\code{\link{FunctionReporter}}}}{: analyze the network of
+    \item{\bold{\code{\link{FunctionReporter}}}}{analyze the network of
        interdependencies of the functions defined in the subject package
     }
-    \item{\bold{\code{\link{InheritanceReporter}}}}{: analyze the class
+    \item{\bold{\code{\link{InheritanceReporter}}}}{analyze the class
        inheritance trees for subject packages that use object-oriented
        programming.
     }
-    \item{\bold{\code{\link{SummaryReporter}}}}{: get an overview of the
+    \item{\bold{\code{\link{SummaryReporter}}}}{get an overview of the
        subject package through its DESCRIPTION file.
     }
   }


### PR DESCRIPTION
I accidentally merged #284 into `master`, when it should have gone to `main`.

This merges its changes to `main`. I'll delete the `master` branch after this is merged.