### PR TITLE
correct legend text in dependency network (fixes #294)

### DIFF
--- a/inst/package_report/package_dependency_reporter.Rmd
+++ b/inst/package_report/package_dependency_reporter.Rmd
@@ -9,8 +9,8 @@ This section analyzes the recursive package dependencies of **`r reporter$pkg_na
 
 In the plot below, you'll see the following colors:
 
-- gray: **`r reporter$pkg_name`**
-- orange: R packages available [in every R session by default](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Default-packages)
+- orange: **`r reporter$pkg_name`**
+- gray: R packages available [in every R session by default](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Default-packages)
 - green: third-party R packages
 
 ```{r echo = FALSE, error = TRUE}


### PR DESCRIPTION
fixes #294

Corrects the legend text so that it matches the text in the actual legend.

### How I tested this

```shell
R CMD install .
```

```r
pkgnet::CreatePackageReport("devtools")
```

<img width="1393" alt="Screen Shot 2022-10-11 at 9 42 45 PM" src="https://user-images.githubusercontent.com/7608904/195237490-f448cae6-c349-4afe-af41-9eecdccb160e.png">
