### PR TITLE
CICD Updates for Igraph changes and Ubuntu Tidy patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 1
+      - name: Install Tidy Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install -y tidy
       - name: set up R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 1
+      - name: Install Tidy
+        run: sudo apt install -y tidy 
       - name: set up R
         shell: bash
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,3 +39,4 @@ License: BSD_3_clause + file LICENSE
 URL: https://github.com/uptake/pkgnet, https://uptake.github.io/pkgnet/
 BugReports: https://github.com/uptake/pkgnet/issues
 RoxygenNote: 7.1.0
+Roxygen: list(r6 = FALSE)

--- a/tests/testthat/test-DependencyReporter-class.R
+++ b/tests/testthat/test-DependencyReporter-class.R
@@ -70,15 +70,15 @@ test_that('DependencyReporter works end-to-end for typical use', {
     expect_true({"DirectedGraph" %in% class(testObj$pkg_graph)})
     expect_true({igraph::is_igraph(testObj$pkg_graph$igraph)})
     expect_setequal(
-        object = igraph::get.vertex.attribute(testObj$pkg_graph$igraph)[['name']]
+        object = igraph::vertex_attr(testObj$pkg_graph$igraph)[['name']]
         , expected = testObj$nodes[, node]
     )
     expect_setequal(
-        object = igraph::get.edgelist(testObj$pkg_graph$igraph)[,1]
+        object = igraph::as_edgelist(testObj$pkg_graph$igraph)[,1]
         , expected = testObj$edges[, SOURCE]
     )
     expect_setequal(
-        object = igraph::get.edgelist(testObj$pkg_graph$igraph)[,2]
+        object = igraph::as_edgelist(testObj$pkg_graph$igraph)[,2]
         , expected = testObj$edges[, TARGET]
     )
 

--- a/tests/testthat/test-DirectedGraph.R
+++ b/tests/testthat/test-DirectedGraph.R
@@ -110,10 +110,13 @@ for (thisTest in testList) {
                 , expected = expectedNodeMeasuresDT[, lapply(.SD, function(x) replace(x, is.na(x), NaN)), .SDcols = c('node', nodeMeas)]
                 , ignore.col.order = TRUE
                 , ignore.row.order = TRUE
-                , info = sprintf("Value testing for %s, %s : %s"
+                , info = sprintf("Value testing for %s, %s : %s /n obj: %s /n exp %s"
                                  , thisTest[['pkg']]
                                  , thisTest[['reporter']]
-                                 , nodeMeas)
+                                 , nodeMeas
+                                 , reporter$pkg_graph$node_measures(nodeMeas)
+                                 , expectedNodeMeasuresDT[, lapply(.SD, function(x) replace(x, is.na(x), NaN)), .SDcols = c('node', nodeMeas)]
+                                 )
             )
         } # /for nodeMeas
     }) # /test_that

--- a/tests/testthat/test-FunctionReporter-class.R
+++ b/tests/testthat/test-FunctionReporter-class.R
@@ -80,15 +80,15 @@ test_that('FunctionReporter works end-to-end for typical use', {
     expect_true({"DirectedGraph" %in% class(testObj$pkg_graph)})
     expect_true({igraph::is_igraph(testObj$pkg_graph$igraph)})
     expect_setequal(
-        object = igraph::get.vertex.attribute(testObj$pkg_graph$igraph)[['name']]
+        object = igraph::vertex_attr(testObj$pkg_graph$igraph)[['name']]
         , expected = testObj$nodes[, node]
     )
     expect_setequal(
-        object = igraph::get.edgelist(testObj$pkg_graph$igraph)[,1]
+        object = igraph::as_edgelist(testObj$pkg_graph$igraph)[,1]
         , expected = testObj$edges[, SOURCE]
     )
     expect_setequal(
-        object = igraph::get.edgelist(testObj$pkg_graph$igraph)[,2]
+        object = igraph::as_edgelist(testObj$pkg_graph$igraph)[,2]
         , expected = testObj$edges[, TARGET]
     )
 

--- a/tests/testthat/test-InheritanceReporter-class.R
+++ b/tests/testthat/test-InheritanceReporter-class.R
@@ -70,15 +70,15 @@ test_that('InheritanceReporter Methods Work', {
     expect_true({"DirectedGraph" %in% class(testObj$pkg_graph)})
     expect_true({igraph::is_igraph(testObj$pkg_graph$igraph)})
     expect_setequal(
-        object = igraph::get.vertex.attribute(testObj$pkg_graph$igraph)[['name']]
+        object = igraph::vertex_attr(testObj$pkg_graph$igraph)[['name']]
         , expected = testObj$nodes[, node]
     )
     expect_setequal(
-        object = igraph::get.edgelist(testObj$pkg_graph$igraph)[,1]
+        object = igraph::as_edgelist(testObj$pkg_graph$igraph)[,1]
         , expected = testObj$edges[, SOURCE]
     )
     expect_setequal(
-        object = igraph::get.edgelist(testObj$pkg_graph$igraph)[,2]
+        object = igraph::as_edgelist(testObj$pkg_graph$igraph)[,2]
         , expected = testObj$edges[, TARGET]
     )
 

--- a/tests/testthat/testdata/node_measures_baseballstats_FunctionReporter.csv
+++ b/tests/testthat/testdata/node_measures_baseballstats_FunctionReporter.csv
@@ -1,6 +1,6 @@
 node,type,isExported,outDegree,inDegree,outCloseness,inCloseness,numRecursiveDeps,numRecursiveRevDeps,betweenness,pageRank,hubScore,authorityScore
 on_base_pct,function,TRUE,0,0,,,0,0,0,0.120882441825325,0,0
 OPS,function,TRUE,2,0,0.75,0.75,3,0,0,0.120882441825325,1,0
-slugging_avg,function,TRUE,1,1,1.00,1.0,1,1,0.5,0.172257479601088,1,1
+slugging_avg,function,TRUE,1,1,1.00,1.0,1,1,0.5,0.172257479601088,1,0.5
 at_bats,function,TRUE,0,2,,,0,3,0,0.413720157147174,0,1
-batting_avg,function,TRUE,1,1,1.00,1.0,1,1,0.5,0.172257479601088,1,1
+batting_avg,function,TRUE,1,1,1.00,1.0,1,1,0.5,0.172257479601088,1,0.5


### PR DESCRIPTION
This PR gets CICD tests back to working status after some updates in [rigraph](https://github.com/igraph/rigraph) and Ubuntu images caused job failures: 

- igraph updated their calculation of authorityScore in igraph release [0.10.5](https://github.com/igraph/igraph/releases/tag/0.10.5).  Consequently, some expected values in tests needed to change. 
- [rigraph](https://github.com/igraph/rigraph) deprecated `get.edgelist` and `get.vertex.attribute` functions. 
- added explicit [Tidy-html5](https://github.com/htacg/tidy-html5) import to github actions to resolve warning in R CMD Check on ubuntu.  Resolves #305