### PR TITLE
extend to do.call case with func param as text (resolves #302)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # pkgnet (dev)
 ## NEW FEATURES
+* `do.call` with the function argument as string will now properly appear on the function reporter.  Previously, this would show as a `do.call` node with a circular reference. (#302)
 
 ## CHANGES
 

--- a/R/FunctionReporter.R
+++ b/R/FunctionReporter.R
@@ -407,6 +407,14 @@ FunctionReporter <- R6::R6Class(
 
 
     if (listable){
+        
+        # If do.call and first argument is string (atomic), covert to call
+        if (length(x) >= 2){
+            if (deparse(x[[1]]) == "do.call" & is.character(x[[2]])){
+                x[[2]] <- parse(text=x[[2]])
+            }
+        }
+        
         # Filter out atomic values because we don't care about them
         x <- Filter(f = Negate(is.atomic), x = x)
 

--- a/inst/baseballstats/R/batting_statistics.R
+++ b/inst/baseballstats/R/batting_statistics.R
@@ -77,7 +77,8 @@ slugging_avg <- function(outcomes){
                       4 * sum(outcomes == 'hr')
                      }
     
-    return(bases_on_hits / at_bats(outcomes))
+    denom <- do.call("at_bats", outcomes)
+    return(bases_on_hits / denom)
 }
 
 


### PR DESCRIPTION
`do.call` with the function argument as string will now properly appear on the function reporter.  Previously, this would show as a `do.call` node with a circular reference. (#302)

This bit of code checks the recursion step for a list with a `do.call` call as the first element and a string as the second.  If true, it converts the string to a call, and then continues with the recursion.  

Note: `baseballstats` test package is changed, BUT because this do.call is in place, network remains identical.  Therefore, unit test for this edge case included. 