### PR TITLE
adds LinkingTo items to dependency reporter (resolves #303)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # pkgnet (dev)
 ## NEW FEATURES
 * `do.call` with the function argument as string will now properly appear on the function reporter.  Previously, this would show as a `do.call` node with a circular reference. (#302)
-* `LinkingTo:` package dependencies are now included in the `DependencyReporter` and subsequent HTML report and objects. (#303) 
+* `LinkingTo:` package dependencies are now included in the `DependencyReporter` and subsequent HTML report and objects. (#319 Thanks @petergodbert !) 
 
 ## CHANGES
 * Updated `pkgnet-intro` vignette to include information on the Class Inheritance Reporter and other minor edits. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # pkgnet (dev)
 ## NEW FEATURES
 * `do.call` with the function argument as string will now properly appear on the function reporter.  Previously, this would show as a `do.call` node with a circular reference. (#302)
+* `LinkingTo:` package dependencies are now included in the `DependencyReporter` and subsequent HTML report and objects. (#303) 
 
 ## CHANGES
 * Updated `pkgnet-intro` vignette to include information on the Class Inheritance Reporter and other minor edits. 
@@ -9,7 +10,7 @@
 
 # pkgnet 0.4.2
 ## NEW FEATURES
-* Node coloring in DependencyReporter (#243)
+* Node coloring in `DependencyReporter` (#243)
 
 ## CHANGES
 * Removed LazyData field to accomodate change in CRAN policy. (#289)

--- a/R/DependencyReporter.R
+++ b/R/DependencyReporter.R
@@ -40,7 +40,7 @@ DependencyReporter <- R6::R6Class(
 
     public = list(
 
-        initialize = function(dep_types = c("Imports", "Depends"), installed = TRUE){
+        initialize = function(dep_types = c("Imports", "Depends", "LinkingTo"), installed = TRUE){
 
             # Check inputs
             assertthat::assert_that(

--- a/inst/milne/DESCRIPTION
+++ b/inst/milne/DESCRIPTION
@@ -13,6 +13,8 @@ Imports:
 Suggests:
     covr,
     testthat
+LinkingTo:
+    Rcpp
 License: file LICENSE
 LazyData: TRUE
 RoxygenNote: 6.1.1

--- a/tests/testthat/test-DependencyReporter-network.R
+++ b/tests/testthat/test-DependencyReporter-network.R
@@ -21,3 +21,23 @@ test_that('DependencyReporter extracts expected network for baseballstats', {
     )
 })
 
+test_that('DependencyReporter extracts expected network for milne (with LinkingTo:)', {
+  
+  testObj <- DependencyReporter$new()$set_package('milne')
+  
+  # Test nodes
+  expect_equivalent(
+    object = testObj$nodes
+    , expected = data.table::fread(file.path('testdata', 'milne_dependency_nodes.csv'))
+    , ignore.col.order = TRUE
+    , ignore.row.order = TRUE
+  )
+  
+  # Test edges
+  expect_equivalent(
+    object = testObj$edges
+    , expected = data.table::fread(file.path('testdata', 'milne_dependency_edges.csv'))
+    , ignore.col.order = TRUE
+    , ignore.row.order = TRUE
+  )
+})

--- a/tests/testthat/testdata/milne_dependency_edges.csv
+++ b/tests/testthat/testdata/milne_dependency_edges.csv
@@ -1,0 +1,11 @@
+SOURCE,TARGET
+Rcpp,methods
+Rcpp,utils
+graphics,grDevices
+methods,stats
+methods,utils
+milne,R6
+milne,Rcpp
+stats,grDevices
+stats,graphics
+stats,utils

--- a/tests/testthat/testdata/milne_dependency_nodes.csv
+++ b/tests/testthat/testdata/milne_dependency_nodes.csv
@@ -1,0 +1,9 @@
+node
+R6
+Rcpp
+grDevices
+graphics
+methods
+milne
+stats
+utils


### PR DESCRIPTION
This PR adds packages listed in the the "LinkingTo:" section of the `DESCRIPTION` file to the list of dependencies.  As noted in #303, these are overlooked today. Note, this also adds the recursive dependencies of the "LinkingTo:" packages to the graph.  

Our test package `milne` has had `Rcpp` added as a "LinkingTo:" dependency for unit testing.  Here's a look at `milne`'s dependency network before and after this change.

<table style="margin: 0px auto;">
<tr>
    <td> <H1 >BEFORE</H1>
   <td> <H1 >AFTER</H1>
  <tr>
    <td> <img src="https://github.com/uptake/pkgnet/assets/24531403/c439f0dc-c5a0-4bba-ba38-4b602916d92c"  alt="before" width = 95%" ></td>
    <td><img src="https://github.com/uptake/pkgnet/assets/24531403/44e68a2e-1cf2-42c9-88c2-780c1d2a180c" alt="after" width = 95%"></td>
   </tr> 
</table>
 
### What Does "LinkingTo:" do? 
In short, if you want to reference C++ headers from another R package, you should list that package under "LinkingTo:".  

More here :point_right:  https://stackoverflow.com/questions/45513058/what-does-linkingto-do-in-an-r-package 
