### PR TITLE
release v0.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,11 @@ jobs:
         run: grep -E "Version:"  $GITHUB_WORKSPACE/DESCRIPTION
       - name: Test if it is a production pattern (#.#.#)
         shell: bash
-        run: grep -E "Version:\s\d+\.\d+\.\d+$"  $GITHUB_WORKSPACE/DESCRIPTION
+        run: |
+          verLine=$(grep -E "Version:"  $GITHUB_WORKSPACE/DESCRIPTION)
+          dots="${verLine//[^.]}"
+          cnt=${#dots}
+          echo $((2-$cnt)) 
   devel_test:
     name: ${{ matrix.os }} (R ${{ matrix.r-version }})
     runs-on: ${{ matrix.os }}
@@ -53,6 +57,13 @@ jobs:
           r-version: ${{ matrix.r-version }}
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-tinytex@v2
+      - run: tlmgr --version
+      - name: Install additional LaTeX Packages
+        run: |
+          tlmgr update --self
+          tlmgr update --all
+          tlmgr install titling framed inconsolata
+          tlmgr install collection-fontsrecommended
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pkgnet
 Type: Package
 Title: Get Network Representation of an R Package
-Version: 0.4.2.9999
+Version: 0.5.0
 Authors@R: c(
     person("Brian", "Burns", email = "brian.burns.opensource@gmail.com", role = c("aut", "cre")),
     person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,16 +1,13 @@
-# pkgnet (dev)
+# pkgnet 0.5.0
 ## NEW FEATURES
 * `do.call` with the function argument as string will now properly appear on the function reporter.  Previously, this would show as a `do.call` node with a circular reference. (#302)
 * `LinkingTo:` package dependencies are now included in the `DependencyReporter` and subsequent HTML report and objects. (#319 Thanks @petergodbert !) 
 
 ## CHANGES
-* Updated `pkgnet-intro` vignette to include information on the Class Inheritance Reporter and other minor edits. 
-<<<<<<< HEAD
-* Recursive functions `.parse_function` and `.parse_R6_expression` made tolerant to control statemets like `break` or `next` that would break the recursion. (#322)
-* Excessive warnings removed for custom `vignette_path` param in `CreatePackageVignette()` (#322)
-=======
-* Updated R6 class documentation to be in line with current `roxygen2` standards. 
->>>>>>> df2fdd4 (latest R6 doc standards for roxygen and pkgdown)
+* Updated `pkgnet-intro` vignette to include information on the Class Inheritance Reporter and other minor edits.    
+* Recursive functions `.parse_function` and `.parse_R6_expression` made tolerant to control statemets like `break` or `next` that would break the recursion. (#322)   
+* Excessive warnings removed for custom `vignette_path` param in `CreatePackageVignette()` (#322)    
+* Updated R6 class documentation to be in line with current `roxygen2` standards.    
 
 ## BUGFIXES
 * `CreatePackageReporter()` failing on Windows to build package coverage when `report_path` specified. (#322) 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,7 +6,7 @@
 This is a minor release that includes a number of new features, bug fixes and minor backwards compatible changes. Please see `NEWS.md` for details.
 
 ### CRAN Response 
-
+None.  Passed tests and merged without comment. 
 
 ## v 0.4.2
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,13 @@
 # CRAN Submission History
 
+## v 0.5.0
+
+### Submission on May 3rd, 2024
+This is a minor release that includes a number of new features, bug fixes and minor backwards compatible changes. Please see `NEWS.md` for details.
+
+### CRAN Response 
+
+
 ## v 0.4.2
 
 ### Submission on December 21st, 2021


### PR DESCRIPTION
This is a minor release that includes a number of new features, bug fixes and minor backwards compatible changes.  This PR will be fully merged AFTER it is CRAN accepted. 

## NEW FEATURES
* `do.call` with the function argument as string will now properly appear on the function reporter.  Previously, this would show as a `do.call` node with a circular reference. (#302)
* `LinkingTo:` package dependencies are now included in the `DependencyReporter` and subsequent HTML report and objects. (#319 Thanks @petergodbert !) 

## CHANGES
* Updated `pkgnet-intro` vignette to include information on the Class Inheritance Reporter and other minor edits.    
* Recursive functions `.parse_function` and `.parse_R6_expression` made tolerant to control statemets like `break` or `next` that would break the recursion. (#322)   
* Excessive warnings removed for custom `vignette_path` param in `CreatePackageVignette()` (#322)    
* Updated R6 class documentation to be in line with current `roxygen2` standards.    

## BUGFIXES
* `CreatePackageReporter()` failing on Windows to build package coverage when `report_path` specified. (#322) 
