### PR TITLE
Button Push Website Build from Last Version Tag

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -9,17 +9,22 @@ on:
 
 jobs:
   build-website:
-    name: build website PR
+    name: build website docs on website_docs_update branch
     runs-on: macos-latest
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # checking out latest tag in next step
+          fetch-depth: 0 # pull all tags and other history
       - name: Get Latest Version Tag
         uses: WyriHaximus/github-action-get-previous-tag@v1.4.0
         with: 
-          prefix: 'v'  
+          prefix: 'v'
+      - name: Git Checkout Branch From Latest Version Tag
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git checkout -b website_docs_update ${{steps.previoustag.outputs.tag}}
       - name: set up R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -32,11 +37,13 @@ jobs:
       - name: Build Site
         run: pkgdown::build_site()
         shell: Rscript {0}
-      - name: Commit website doc changes
+      - name: Save Site Docs Articfact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "built_website_docs_${{steps.previoustag.outputs.tag}}"
+          path: ${{github.workspace}}/docs/
+      - name: Commit website doc changes (overwrite if existing)
         run: |
-            git config --local user.name "$GITHUB_ACTOR"
-            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-            git checkout -b website_update_${{steps.previoustag.outputs.tag}}
             git add docs/\*
             git commit -m "Update website documentation to ${{steps.previoustag.outputs.tag}}" || echo "No changes to commit"
-            git push origin website_update_${{steps.previoustag.outputs.tag}}
+            git push -f origin website_docs_update

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -25,7 +25,11 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0 # checking out latest tag in next step
+      - name: Get Latest Version Tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1.4.0
+        with: 
+          prefix: 'v'  
       - name: set up R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -42,7 +46,7 @@ jobs:
         run: |
             git config --local user.name "$GITHUB_ACTOR"
             git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git checkout -b website_update_${{steps.previoustag.outputs.tag}}
             git add docs/\*
-            git commit -m "Update website documentation" || echo "No changes to commit"
-            git pull --ff-only
-            git push origin
+            git commit -m "Update website documentation to ${{steps.previoustag.outputs.tag}}" || echo "No changes to commit"
+            git push origin website_update_${{steps.previoustag.outputs.tag}}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0 # pull all tags and other history
       - name: Get Latest Version Tag
+        id: previoustag
         uses: WyriHaximus/github-action-get-previous-tag@v1.4.0
         with: 
           prefix: 'v'

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -8,18 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  version_check:
-    name: Confirm Whole Version Number
-    runs-on: macos-latest
-    steps:
-      - name: checkout repository
-        uses: actions/checkout@v4
-      - name: Grep Version in DESCRIPTION
-        shell: bash
-        run: grep -E "Version:\s\d+\.\d+\.\d+$"  $GITHUB_WORKSPACE/DESCRIPTION
   build-website:
     name: build website PR
-    needs: [version_check]
     runs-on: macos-latest
     steps:
       - name: checkout repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,7 +346,7 @@ Add some notes explaining what has changed since the previous release (usually a
 
 ### Update the Website
 
-Adding the new version tag in the previous step should have triggered a Github Action to build the website docs and create a branch named `website_docs_update`.  Review and   merge.
+Adding the new version tag in the previous step should have triggered a Github Action to build the website docs and create a branch named `website_docs_update`. Review and merge.
 
 ### Open a new PR to begin development on the next version
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,7 +346,7 @@ Add some notes explaining what has changed since the previous release (usually a
 
 ### Update the Website
 
-Adding the new version tag in the previous step should have triggered a Github Action to build the website docs and create a PR.  If not, manually trigger the workflow and create a PR to update the docs.  Merge that in!
+Adding the new version tag in the previous step should have triggered a Github Action to build the website docs and create a branch named `website_docs_update`.  Review and   merge.
 
 ### Open a new PR to begin development on the next version
 


### PR DESCRIPTION
This edits the `website.yaml` workflow to build `docs/` from the last version tag (it is triggered after this event) and create a branch titled `website_docs_update`.  It will overwrite that branch if it exists already.  In this way, docs are ready to go for a PR, review & merge. 

In addition, I added a workflow file to update our gallery with a button push: https://github.com/uptake/pkgnet-gallery/pull/34
The gallery is kept separate for design decisions explained on that repo's README. 

Resolves #326 