### PR TITLE
Avoid partial matching

### DIFF
--- a/inst/package_report/package_report.Rmd
+++ b/inst/package_report/package_report.Rmd
@@ -4,7 +4,7 @@ output:
   html_document:
     self_contained: TRUE
     theme: flatly
-    include:
+    includes:
       in_header: header.html
       after_body: footer.html
 params:


### PR DESCRIPTION
Caught by using 

```r
  options(
    warnPartialMatchArgs = TRUE,
    warnPartialMatchDollar = TRUE,
    warnPartialMatchAttr = TRUE
  )
```
