### PR TITLE
Move rmarkdown::render action to happen in a temp directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 ## CHANGES  
 
 ## BUGFIXES
+* Moved `rmarkdown::render` interium files to occur within a temp directory, not the installed package directory (#329 Thanks @jcarbaut!) 
 
 # pkgnet 0.5.0
 ## NEW FEATURES

--- a/R/testing_utils.R
+++ b/R/testing_utils.R
@@ -104,3 +104,29 @@
 
     return(invisible(TRUE))
 }
+
+
+# Get Files with Modification Date after a specific date
+# Used to provide more verbose logging in the event package directory is modified.
+# Will not list files created and deleted in the interium but it helps.
+.printModifiedFiles <- function(dir_path, after_posixct){
+    file_list <- list.files(
+        path = dir_path,
+        full.names = TRUE
+    )
+
+    print(sprintf("FILE INFO FOR UPDATES AFTER %s", as.character(after_posixct)))
+    for (file in file_list){
+        info <- as.list(file.info(file))
+        if (info['mtime'] > after_posixct){
+            msg <- sprintf(
+                "%s %s %s %s",
+                file,
+                info['mtime'],
+                info['mode'],
+                info['isdir']
+            )
+            print(msg)
+        }
+    }
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -57,6 +57,11 @@ if(identical(Sys.getenv("NOT_CRAN"), "true")){
 
     }
 
+    # Record modifaction time of package directory to be checked at end of testing 
+    # in test-Z-test-no-source-modifcations.R
+    tmp_pkgnet_path <- file.path(Sys.getenv('PKGNET_TEST_LIB'), 'pkgnet')
+    Sys.setenv(PKGNET_LATEST_MOD = as.character(file.info(tmp_pkgnet_path)$mtime))
+
     # This withr statement should be redundant.
     # This is within a test environment in which .libpaths() has been altered to include PKGNET_TEST_LIB.
     # Yet, it appears to be necessary.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -57,11 +57,6 @@ if(identical(Sys.getenv("NOT_CRAN"), "true")){
 
     }
 
-    # Record modifaction time of package directory to be checked at end of testing 
-    # in test-Z-test-no-source-modifcations.R
-    tmp_pkgnet_path <- file.path(Sys.getenv('PKGNET_TEST_LIB'), 'pkgnet')
-    Sys.setenv(PKGNET_LATEST_MOD = as.character(file.info(tmp_pkgnet_path)$mtime))
-
     # This withr statement should be redundant.
     # This is within a test environment in which .libpaths() has been altered to include PKGNET_TEST_LIB.
     # Yet, it appears to be necessary.

--- a/tests/testthat/test-0-test-package-installation.R
+++ b/tests/testthat/test-0-test-package-installation.R
@@ -13,3 +13,8 @@ test_that('Test packages installed correctly',{
         )
     }
 })
+
+# Record modifaction time of package directory to be checked at end of testing 
+# in test-Z-test-no-source-modifcations.R
+tmp_pkgnet_path <- file.path(Sys.getenv('PKGNET_TEST_LIB'), 'pkgnet')
+Sys.setenv(PKGNET_LATEST_MOD = as.character(file.info(tmp_pkgnet_path)$mtime))

--- a/tests/testthat/test-Z-test-no-source-modifcations.R
+++ b/tests/testthat/test-Z-test-no-source-modifcations.R
@@ -1,0 +1,21 @@
+# Inditended to be run last, this is to confirm that no files 
+# within the package directory are modified during the normal 
+# operation of pkgnet during these tests.  This includes the 
+# creation and deletion of temp files for rendering. 
+
+test_that('No modification to pkgnet directory during testing',{
+    startModTime <- as.POSIXct(Sys.getenv('PKGNET_LATEST_MOD'))
+    
+    tmp_pkgnet_path <- file.path(Sys.getenv('PKGNET_TEST_LIB'), 'pkgnet')
+    currentModTime <- file.info(tmp_pkgnet_path)$mtime
+
+    if (as.character(startModTime) != as.character(currentModTime)){
+        pkgnet:::.printModifiedFiles(tmp_pkgnet_path, startModTime)
+    }
+
+    expect_equal(object = currentModTime
+                 , expected = startModTime
+                 , info = "The source directory was modified during the execution of tests."
+                 )
+
+})


### PR DESCRIPTION
This resolves #329 (thanks @jcarbaut for the catch!) 

Better detailed in the bug issue above, the issue is that when we called `rmarkdown::render` to render the report from an Rmd file within the installed package directory, it creates interim files within the installed package directory.  This is technically a CRAN violation.  It is rectified in line with `rmarkdown`'s recommendation for this issue which is to move all Rmd files to a temp directory and then call `rmarkdown::render` there. 

**Why didn't we catch this before?**
My money is on:
- The authors use more forgiving directories for installation, so missed the opportunity to catch this issue here.  
- Our test process involves installing `pkgnet` as well as all test packages in a temporary directory for testing.  Therefore, these modifications of the installed directory were happening within the temp directory, leaving the original directory untouched. 
- The interim files are created and deleted within the run, so a cursory before and after look at file structure won't necessarily catch this. 


 **Why didn't CRAN catch this before?**
We have passed CRAN checks for years.  My guess is that that our unique process of installing within a temp directory for testing is what allowed this error to go undetected. 

For our unit tests, we now leverage `file.info()` to compare last modification date for the package directory (installed within a temporary directory) before and after testing. A change in this date can catch this error.  