### PR TITLE
FIX : rare multiple values in deparse

### DIFF
--- a/R/FunctionReporter.R
+++ b/R/FunctionReporter.R
@@ -420,7 +420,7 @@ FunctionReporter <- R6::R6Class(
         
         # If do.call and first argument is string (atomic), covert to call
         if (length(x) >= 2){
-            if (deparse(x[[1]]) == "do.call" & is.character(x[[2]])){
+            if (deparse(x[[1]])[1] == "do.call" & is.character(x[[2]])){
                 x[[2]] <- parse(text=x[[2]])
             }
         }


### PR DESCRIPTION
Hi,

Working on client R package, ``pkgnet`` shows errors on ``Function Network`` page : 

![image](https://github.com/uptake/pkgnet/assets/8750326/ee3f89e8-dfe2-4e9f-a2d8-ade331e06897)

It's seems to due to (rare) case of multiple expression in deparse object. One simple fix is to check only first value (or perhaps used ``%in%`` ?)